### PR TITLE
Fix: Add path traversal protection to DirectivePlugin (APSB26-05)

### DIFF
--- a/Plugin/Controller/Adminhtml/Wysiwyg/DirectivePlugin.php
+++ b/Plugin/Controller/Adminhtml/Wysiwyg/DirectivePlugin.php
@@ -8,10 +8,14 @@ namespace MagestyApps\WebImages\Plugin\Controller\Adminhtml\Wysiwyg;
 
 use Magento\Cms\Controller\Adminhtml\Wysiwyg\Directive;
 use Magento\Cms\Model\Template\Filter;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\Filesystem\DirectoryResolver;
 use Magento\Framework\Controller\Result\Raw;
 use Magento\Framework\Controller\Result\RawFactory;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Url\DecoderInterface;use MagestyApps\WebImages\Helper\ImageHelper;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Url\DecoderInterface;
+use MagestyApps\WebImages\Helper\ImageHelper;
 
 class DirectivePlugin
 {
@@ -36,22 +40,38 @@ class DirectivePlugin
     private $imageHelper;
 
     /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var DirectoryResolver
+     */
+    private $directoryResolver;
+
+    /**
      * DirectivePlugin constructor.
      * @param DecoderInterface $urlDecoder
      * @param Filter $filter
      * @param RawFactory $resultRawFactory
      * @param ImageHelper $imageHelper
+     * @param Filesystem $filesystem
+     * @param DirectoryResolver $directoryResolver
      */
     public function __construct(
         DecoderInterface $urlDecoder,
         Filter $filter,
         RawFactory $resultRawFactory,
-        ImageHelper $imageHelper
+        ImageHelper $imageHelper,
+        Filesystem $filesystem,
+        DirectoryResolver $directoryResolver
     ) {
         $this->urlDecoder = $urlDecoder;
         $this->filter = $filter;
         $this->resultRawFactory = $resultRawFactory;
         $this->imageHelper = $imageHelper;
+        $this->filesystem = $filesystem;
+        $this->directoryResolver = $directoryResolver;
     }
 
     /**
@@ -67,15 +87,25 @@ class DirectivePlugin
             $directive = $subject->getRequest()->getParam('___directive');
             $directive = $this->urlDecoder->decode($directive);
             $imagePath = $this->filter->filter($directive);
+            $imagePath = str_replace('\\', '/', $imagePath);
 
             if (!$this->imageHelper->isVectorImage($imagePath)) {
                 throw new LocalizedException(__('This is not a vector image'));
             }
 
+            $urlPath = $this->filesystem->getUri(DirectoryList::MEDIA);
+            $relativeFilePath = str_replace(rtrim($urlPath, '/') . '/', '', $imagePath);
+            $mediaDirectory = $this->filesystem->getDirectoryRead(DirectoryList::MEDIA);
+            $absolutePath = $mediaDirectory->getAbsolutePath($relativeFilePath);
+
+            if (!$this->directoryResolver->validatePath($absolutePath, DirectoryList::MEDIA)) {
+                throw new LocalizedException(__('Invalid Path'));
+            }
+
             /** @var Raw $resultRaw */
             $resultRaw = $this->resultRawFactory->create();
             $resultRaw->setHeader('Content-Type', 'image/svg+xml');
-            $resultRaw->setContents(file_get_contents($imagePath));
+            $resultRaw->setContents($mediaDirectory->readFile($relativeFilePath));
 
             return $resultRaw;
         } catch (\Exception $e) {


### PR DESCRIPTION
## Summary

Magento 2.4.6-p14 security patch (APSB26-05) added path traversal protection to `Magento\Cms\Controller\Adminhtml\Wysiwyg\Directive::execute()` via `DirectoryResolver::validatePath()`. This ensures that only files within the `pub/media/` directory can be served.

However, `DirectivePlugin::aroundExecute()` returns early for SVG/vector images **before** calling `$proceed()`, which means the new security validation is completely bypassed for vector image requests.

### Security Issue

An admin user could craft a `___directive` parameter that resolves to a path outside `pub/media/` (e.g., `../../app/etc/env.php`). If the file passes `isVectorImage()` check (extension or MIME type), its contents would be returned via `file_get_contents()` without any path validation.

### Changes

- **Add `DirectoryResolver`** to validate that the resolved file path is within the media directory
- **Add `Filesystem`** for proper path resolution via `getAbsolutePath()` (consistent with core Magento approach)
- **Normalize path separators** (`\` → `/`) before processing
- **Replace `file_get_contents()`** with `$mediaDirectory->readFile()` to use Magento's filesystem abstraction instead of raw PHP file access

### Affected Magento Versions

All Magento installations using `magestyapps/module-web-images` with Magento 2.4.6-p14+ (and likely earlier versions that had less comprehensive but still relevant path handling).

### Testing

1. Upload an SVG image via WYSIWYG media gallery → should render correctly (no regression)
2. Attempt to access a file outside `pub/media/` via crafted directive → should fail with "Invalid Path" exception and fall through to `$proceed()`